### PR TITLE
acts_as_tenant helper can point to deep join

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -28,6 +28,9 @@ module ActsAsTenant
               query_criteria = {options[:through] => {fkey.to_sym => keys}}
               query_criteria[polymorphic_type.to_sym] = ActsAsTenant.current_tenant.class.to_s if options[:polymorphic]
               joins(options[:through]).where(query_criteria)
+            elsif options[:deep_through]
+              query_criteria = {options[:deep_through][:through_2] => {fkey.to_sym => keys}}
+              joins(options[:deep_through][:through_1] => options[:deep_through][:through_2]).where(query_criteria)
             else
               query_criteria = {fkey.to_sym => keys}
               query_criteria[polymorphic_type.to_sym] = ActsAsTenant.current_tenant.class.to_s if options[:polymorphic]
@@ -47,6 +50,12 @@ module ActsAsTenant
             if options[:polymorphic]
               m.send("#{fkey}=".to_sym, ActsAsTenant.current_tenant.class.to_s) if m.send(fkey.to_s).nil?
               m.send("#{polymorphic_type}=".to_sym, ActsAsTenant.current_tenant.class.to_s) if m.send(polymorphic_type.to_s).nil?
+            elsif options[:through] 
+              model = m.send options[:through]
+              model.send(fkey.to_s) if model.send(fkey.to_s).present?
+            elsif options[:deep_through] 
+              model = m.send options[:deep_through][:through_1]
+              model.send(fkey.to_s) if model.send(fkey.to_s).present?
             else
               m.send "#{fkey}=".to_sym, ActsAsTenant.current_tenant.send(pkey)
             end


### PR DESCRIPTION
If your model doesn't have the tenant id but an associated model does you can use the following patterns to point to a foreign tenant id in an associated model.

# Example 1
When a parent model has the tenant id. Use `through` option
```
class Book < ApplicationRecord
  belongs_to :user

  acts_as_tenant :tenant, through: :user
  delegate :tenant, :tenant_id, to: :user
end
```

# Example 2
When a parent, of a parent model, has the tenant id. Use `deep_through` option
```
class Review < ApplicationRecord
  belongs_to :book

  acts_as_tenant :tenant, deep_through: { through_1: :book, through_2: :user }
  delegate :tenant, :tenant_id, to: :book
end
```